### PR TITLE
Allow HTML log ingestion on reporters

### DIFF
--- a/testipy/__init__.py
+++ b/testipy/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 
-__version__ = "0.10.4"
+__version__ = "0.10.5"
 __app__ = "TestiPy"
 __app_full__ = "Python Test Tool"
 __author__ = "Pedro Nunes"

--- a/testipy/models/package_manager.py
+++ b/testipy/models/package_manager.py
@@ -17,6 +17,7 @@ class TestInfo(NamedTuple):
     level: str
     info: str
     attachment: Dict[str, Any]
+    true_html: bool
 
 
 class CommonDetails:
@@ -131,7 +132,7 @@ class TestDetails(CommonDetails):
         self.test_state: str = ""
         self.test_reason_of_state: str = ""
 
-        self._info: List[TestInfo] = list()
+        self._info: List[TestInfo] = []
         self._test_step: StateCounter = StateCounter()
 
     def get_rm(self) -> ReportManager:
@@ -189,8 +190,8 @@ class TestDetails(CommonDetails):
     def get_features(self) -> str:
         return self.test_method_attr.features
 
-    def add_info(self, ts: int, current_time: str, level: str, info: str, attachment: Dict):
-        self._info.append(TestInfo(ts, current_time, str(level).upper(), info, attachment))
+    def add_info(self, ts: int, current_time: str, level: str, info: str, attachment: Dict, true_html: bool):
+        self._info.append(TestInfo(ts, current_time, str(level).upper(), info, attachment, true_html))
 
     def get_info(self) -> List[TestInfo]:
         return list(self._info)

--- a/testipy/reporter/report_base.py
+++ b/testipy/reporter/report_base.py
@@ -131,8 +131,8 @@ class ReportBase(ReportInterface):
     def start_test(self, current_test: TestDetails):
         pass
 
-    def test_info(self, current_test, info, level, attachment=None):
-        current_test.add_info(get_timestamp(), get_current_date_time_ns(), level, info, attachment)
+    def test_info(self, current_test, info, level, attachment=None, true_html=False):
+        current_test.add_info(get_timestamp(), get_current_date_time_ns(), level, info, attachment, true_html)
 
     def test_step(self, current_test, state: str, reason_of_state: str = "", description: str = "", take_screenshot: bool = False, qty: int = 1, exc_value: BaseException = None):
         current_test.test_step(state, reason_of_state=reason_of_state, description=description, qty=qty, exc_value=exc_value)

--- a/testipy/reporter/report_interfaces.py
+++ b/testipy/reporter/report_interfaces.py
@@ -53,7 +53,7 @@ class ReportInterface(ABC):
         pass
 
     @abstractmethod
-    def test_info(self, current_test: TestDetails, info: str, level: str, attachment: Dict=None):
+    def test_info(self, current_test: TestDetails, info: str, level: str, attachment: Dict=None, true_html: bool = False):
         pass
 
     @abstractmethod

--- a/testipy/reporter/report_manager.py
+++ b/testipy/reporter/report_manager.py
@@ -151,11 +151,11 @@ class ReportManager(ReportBase, ReportManagerAddons):
                     raise
 
     @synchronized
-    def test_info(self, current_test: TestDetails, info: str, level: str = "DEBUG", attachment: Dict = None) -> ReportManager:
-        super().test_info(current_test, info, level, attachment)
+    def test_info(self, current_test: TestDetails, info: str, level: str = "DEBUG", attachment: Dict = None, true_html: bool = False) -> ReportManager:
+        super().test_info(current_test, info, level, attachment, true_html)
         for reporter_name, reporter in self._reporters_list.items():
             try:
-                reporter.test_info(current_test, info, str(level).upper(), attachment)
+                reporter.test_info(current_test, info, str(level).upper(), attachment, true_html)
             except Exception as e:
                 _exec_logger.critical(f"Internal error rm.test_info on {reporter_name}: {e}")
                 if self.is_debugcode():

--- a/testipy/reporter/reporters/reporter_echo.py
+++ b/testipy/reporter/reporters/reporter_echo.py
@@ -86,11 +86,10 @@ class ReporterEcho(ReportInterface):
         print("-" * _line_size)
         print(f"> Starting test: {current_test} <".center(_line_size, "-"))
 
-    def test_info(self, current_test: TestDetails, info: str, level: str, attachment: Dict=None):
+    def test_info(self, current_test: TestDetails, info: str, level: str, attachment: Dict=None, true_html: bool = False):
         full_name = current_test.get_full_name(with_cycle_number=True)
-        usecase = current_test.get_usecase()
-
-        print(f"{level} {full_name}: {prettify(info)}")
+        if not true_html:
+            print(f"{level} {full_name}: {prettify(info)}")
 
     def test_step(self,
                   current_test: TestDetails,

--- a/testipy/reporter/reporters/reporter_excel.py
+++ b/testipy/reporter/reporters/reporter_excel.py
@@ -95,7 +95,7 @@ class ReporterExcel(ReportInterface):
     def start_test(self, current_test: TestDetails):
         pass
 
-    def test_info(self, current_test: TestDetails, info, level, attachment=None):
+    def test_info(self, current_test: TestDetails, info, level, attachment=None, true_html: bool = False):
         pass
 
     def test_step(

--- a/testipy/reporter/reporters/reporter_html.py
+++ b/testipy/reporter/reporters/reporter_html.py
@@ -108,7 +108,7 @@ class ReporterHtml(ReportInterface):
     def start_test(self, current_test: TestDetails):
         pass
 
-    def test_info(self, current_test: TestDetails, info, level, attachment=None):
+    def test_info(self, current_test: TestDetails, info, level, attachment=None, true_html: bool = False):
         pass
 
     def test_step(
@@ -328,8 +328,10 @@ def _format_info(current_test: TestDetails, ending_state: str, end_reason: str):
     str_res += escaped_text("      Took: ") + f"{format_duration(current_test.get_duration())}"
 
     # add test info log
-    for ts, current_time, level, info, attachment in current_test.get_info():
-        data = f"<p>{escaped_text(info)}</p>{get_image_from_attachment(attachment)}"
+    for ts, current_time, level, info, attachment, true_html in current_test.get_info():
+        if not true_html:
+            info = escaped_text(info)
+        data = f"<p>{info}</p>{get_image_from_attachment(attachment)}"
         str_res += f"<hr><strong>{current_time} {level}</strong><br>{data}"
 
     # add test steps

--- a/testipy/reporter/reporters/reporter_junit.py
+++ b/testipy/reporter/reporters/reporter_junit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import List, TYPE_CHECKING
+from xml.sax.saxutils import escape
 import os
 
 from testipy import get_exec_logger
@@ -63,7 +64,7 @@ class ReporterJUnitXML(ReportInterface):
     def start_test(self, current_test: TestDetails):
         pass
 
-    def test_info(self, current_test: TestDetails, info, level, attachment=None):
+    def test_info(self, current_test: TestDetails, info, level, attachment=None, true_html: bool = False):
         pass
 
     def test_step(
@@ -204,12 +205,12 @@ class ReporterJUnitXML(ReportInterface):
                 category = file = method = code = "-"
                 line = 0
 
-            xml_file.write(f"{failure_type}: {reason_of_state}\n")
-            xml_file.write(f"Category: {category}\n")
-            xml_file.write(f"File: {file}\n")
-            xml_file.write(f"Line: {line}\n")
-            xml_file.write(f"Method: {method}\n")
-            xml_file.write(f"Code: {code}\n")
+            xml_file.write(f"Category: {escape(category)}\n")
+            xml_file.write(f" Message: {escape(reason_of_state)}\n")
+            xml_file.write(f"    File: {escape(file)}\n")
+            xml_file.write(f"    Line: {line}\n")
+            xml_file.write(f"  Method: {escape(method)}\n")
+            xml_file.write(f"    Code: {escape(code)}\n")
 
             xml_file.write("   </failure>\n")
 
@@ -217,4 +218,4 @@ class ReporterJUnitXML(ReportInterface):
 def string_fixer(text):
     if not isinstance(text, str):
         text = str(text)
-    return text.replace('"', "'").replace("\n", " | ")
+    return escape(text.replace('"', "'").replace("\n", " | "))

--- a/testipy/reporter/reporters/reporter_log.py
+++ b/testipy/reporter/reporters/reporter_log.py
@@ -150,9 +150,10 @@ class ReporterLog(ReportInterface):
         test_full_name = current_test.get_full_name(with_cycle_number=True)
         self.__log(f"Starting Test {test_full_name}", "INFO")
 
-    def test_info(self, current_test: TestDetails, info, level, attachment=None):
-        test_full_name = current_test.get_full_name(with_cycle_number=True)
-        self.__log(f"{test_full_name}: {info}", level)
+    def test_info(self, current_test: TestDetails, info, level, attachment=None, true_html: bool = False):
+        if not true_html:
+            test_full_name = current_test.get_full_name(with_cycle_number=True)
+            self.__log(f"{test_full_name}: {info}", level)
 
     def test_step(
         self,

--- a/testipy/reporter/reporters/reporter_portalio.py
+++ b/testipy/reporter/reporters/reporter_portalio.py
@@ -151,7 +151,7 @@ class ReporterPortalIO(ReportInterface):
                     "end_state": enums_data.STATE_PASSED,
                 }
 
-    def test_info(self, current_test, info, level, attachment=None):
+    def test_info(self, current_test, info, level, attachment=None, true_html: bool = False):
         pass
 
     def test_step(
@@ -232,12 +232,13 @@ class ReporterPortalIO(ReportInterface):
         self._service.finish_test_item(end_time=end_time, status=ending_state, item_id=usecase_id, issue=issue)
 
     def __log_infos(self, current_test, item_id):
-        for ts, _, level, info, attachment in current_test.get_info():
-            if isinstance(attachment, dict):
-                attachment["name"] = os.path.basename(attachment["name"])
-            else:
-                attachment = None
-            self._service.log(time=str(ts), message=str(info), level=level, attachment=attachment, item_id=item_id)
+        for ts, _, level, info, attachment, true_html in current_test.get_info():
+            if not true_html:
+                if isinstance(attachment, dict):
+                    attachment["name"] = os.path.basename(attachment["name"])
+                else:
+                    attachment = None
+                self._service.log(time=str(ts), message=str(info), level=level, attachment=attachment, item_id=item_id)
 
     def __log_test_steps(self, current_test, item_id):
         tc = current_test.get_test_step_counters()

--- a/testipy/reporter/reporters/reporter_slack.py
+++ b/testipy/reporter/reporters/reporter_slack.py
@@ -84,7 +84,7 @@ class ReporterSlack(ReportInterface):
     def start_test(self, current_test: TestDetails):
         pass
 
-    def test_info(self, current_test: TestDetails, info, level, attachment=None):
+    def test_info(self, current_test: TestDetails, info, level, attachment=None, true_html: bool = False):
         pass
 
     def test_step(

--- a/testipy/reporter/reporters/reporter_template.py
+++ b/testipy/reporter/reporters/reporter_template.py
@@ -43,7 +43,7 @@ class ReporterTemplate(ReportInterface):
     def start_test(self, current_test: TestDetails):
         pass
 
-    def test_info(self, current_test: TestDetails, info, level, attachment=None):
+    def test_info(self, current_test: TestDetails, info, level, attachment=None, true_html: bool = False):
         pass
 
     def test_step(

--- a/testipy/reporter/reporters/reporter_web.py
+++ b/testipy/reporter/reporters/reporter_web.py
@@ -205,8 +205,10 @@ class ReporterWeb(ReportInterface):
 
         self.test_info(current_test, f"Test details:\n{prettify(current_test.get_attr())}", "DEBUG")
 
-    def test_info(self, current_test: TestDetails, info, level, attachment=None):
-        data = f"<p>{escaped_text(info)}</p>{get_image_from_attachment(attachment)}"
+    def test_info(self, current_test: TestDetails, info, level, attachment=None, true_html: bool = False):
+        if not true_html:
+            info = escaped_text(info)
+        data = f"<p>{info}</p>{get_image_from_attachment(attachment)}"
         msg = {"test_id": current_test.get_test_id(), "data": data}
         self._notify_clients("test_info", msg)
 
@@ -286,8 +288,10 @@ class ReporterWeb(ReportInterface):
         str_res += escaped_text("      Took: ") + f"{format_duration(current_test.get_duration())}"
 
         # add test info log
-        for ts, current_time, level, info, attachment in current_test.get_info():
-            data = f"<p>{escaped_text(info)}</p>{get_image_from_attachment(attachment)}"
+        for ts, current_time, level, info, attachment, true_html in current_test.get_info():
+            if not true_html:
+                info = escaped_text(info)
+            data = f"<p>{info}</p>{get_image_from_attachment(attachment)}"
             str_res += f"<hr><strong>{current_time} {level}</strong><br>{data}"
 
         # add test steps


### PR DESCRIPTION
* Allows to ingest pure HTML when doing test_info() for HTML reporters
* Escape text for junit reporter